### PR TITLE
Fix map to main

### DIFF
--- a/baitUtils/__main__.py
+++ b/baitUtils/__main__.py
@@ -3,7 +3,7 @@
 import argparse
 import sys
 from baitUtils._version import __version__  # Import version from _version.py
-from baitUtils import stats, plot
+from baitUtils import stats, plot, map 
 
 
 def main():
@@ -20,6 +20,11 @@ def main():
     parser_plot = subparsers.add_parser("plot", help="Generate plots from bait statistics")
     plot.add_arguments(parser_plot)
     parser_plot.set_defaults(func=plot.main)
+
+    # Subcommand for map
+    parser_map = subparsers.add_parser("map", help="Map baits against target and off-target sequences")
+    map.add_arguments(parser_map)
+    parser_map.set_defaults(func=map.main)
 
     args = parser.parse_args()
     if hasattr(args, "func"):


### PR DESCRIPTION
This pull request includes an update to the `baitUtils` package, specifically adding a new subcommand for mapping baits against target and off-target sequences.

Enhancements to `baitUtils`:

* [`baitUtils/__main__.py`](diffhunk://#diff-b48682ee95d7b788d159f227df7ecf30b1de9f635c6ec09ff664d7d36b4bc7fdL6-R6): Imported the `map` module to include new functionality for mapping baits.
* [`baitUtils/__main__.py`](diffhunk://#diff-b48682ee95d7b788d159f227df7ecf30b1de9f635c6ec09ff664d7d36b4bc7fdR24-R28): Added a new subcommand `map` with appropriate argument parsing and function setting in the `main` function.